### PR TITLE
correction for usd value : two digits after the decimal point

### DIFF
--- a/src/app/shared/pipes/showNumbersRule.ts
+++ b/src/app/shared/pipes/showNumbersRule.ts
@@ -40,14 +40,21 @@ export class ShowNumbersRule implements PipeTransform {
         for (const rule of numberRules) {
           if(rule.range[0] === 10000) {
             if(bigValue.gte(rule.range[0])) {
-              if(modeCryptoList) return this.handleFormattedValue(bigValue, '0.0-2')
-              return this.handleFixedValue(bigValue, rule.precision)
+              if(modeCryptoList) return this.handleFixedValue(bigValue, rule.precision)
+              return this.handleFormattedValue(bigValue, '0.0-2')
             }
           } else {
             if(bigValue.gte(rule.range[0]) && bigValue.lte(rule.range[1])) {
-              if(modeCryptoList && rule.range[0] === 10) {
-                return this.handleFormattedValue(bigValue, '0.0-2')
-              } else return this.handleFixedValue(bigValue, rule.precision)
+              if(rule.range[0] === 10) {
+                if(modeCryptoList) {
+                  return this.handleFixedValue(bigValue, rule.precision)
+                } else return this.handleFormattedValue(bigValue, '0.0-2')
+              } else {
+                if(modeCryptoList) {
+                  return this.handleFixedValue(bigValue, rule.precision)
+                } else return this.handleFormattedValue(bigValue, '0.0-2')
+                
+              }
             }
           }
         }

--- a/src/app/shared/pipes/showNumbersRule.ts
+++ b/src/app/shared/pipes/showNumbersRule.ts
@@ -25,39 +25,26 @@ export class ShowNumbersRule implements PipeTransform {
    * @param value
    */
   transform(value: string, modeCryptoList?: boolean): string {
-    if (value) {
-      const bigValue = isNaN(+value) ? new Big(0) : new Big(value);
-      if (bigValue.div(1).toNumber() === 0) {
-        return '0';
-      } else {
-        const numberRules = [
-          { range: [0, 0.1], precision: 8 },
-          { range: [0.1, 1.9], precision: 6 },
-          { range: [2, 9.9999], precision: 4 },
-          { range: [10, 9999.99], precision: 2 },
-          { range: [10000, Infinity], precision: 2 }
-        ];
-        for (const rule of numberRules) {
-          if(rule.range[0] === 10000) {
-            if(bigValue.gte(rule.range[0])) {
-              if(modeCryptoList) return this.handleFixedValue(bigValue, rule.precision)
-              return this.handleFormattedValue(bigValue, '0.0-2')
-            }
-          } else {
-            if(bigValue.gte(rule.range[0]) && bigValue.lte(rule.range[1])) {
-              if(rule.range[0] === 10) {
-                if(modeCryptoList) {
-                  return this.handleFixedValue(bigValue, rule.precision)
-                } else return this.handleFormattedValue(bigValue, '0.0-2')
-              } else {
-                if(modeCryptoList) {
-                  return this.handleFixedValue(bigValue, rule.precision)
-                } else return this.handleFormattedValue(bigValue, '0.0-2')
-                
-              }
-            }
-          }
-        }
+    if (!value) {
+      return value;
+    }
+    const bigValue = isNaN(+value) ? new Big(0) : new Big(value);
+    if (bigValue.div(1).toNumber() === 0) {
+      return '0';
+    }
+    const numberRules = [
+      { range: [0, 0.1], precision: 8 },
+      { range: [0.1, 1.9], precision: 6 },
+      { range: [2, 9.9999], precision: 4 },
+      { range: [10, 9999.99], precision: 2 },
+      { range: [10000, Infinity], precision: 2 }
+    ];
+    for (const rule of numberRules) {
+      const [lower, upper] = rule.range;
+      if (bigValue.gte(lower) && (upper === Infinity || bigValue.lte(upper))) {
+        return modeCryptoList
+          ? this.handleFixedValue(bigValue, rule.precision)
+          : this.handleFormattedValue(bigValue, '0.0-2');
       }
     }
     return value;

--- a/src/app/wallet/components/crypto-list/crypto-list.component.ts
+++ b/src/app/wallet/components/crypto-list/crypto-list.component.ts
@@ -744,7 +744,7 @@ export class CryptoListComponent implements OnInit, OnDestroy {
     else {
       sum = crypto.total_balance;
     }
-    return this.showNumbersRule.transform((!!sum ? sum : 0) + '', true);
+    return this.showNumbersRule.transform((!!sum ? sum : 0) + '', false);
   }
 
   quantitySum(crypto: any, modeDetails?: boolean) {


### PR DESCRIPTION
## PR Description

Hey team,

This PR addresses an issue with the number rules for USD display value in our Angular app. Currently, the `showNumbersRule` Pipe does not consider the `modeCryptoList` condition when handling USD values. Additionally, we have modified the calling code to pass `false` for `modeCryptoList` when dealing with USD values. To resolve this issue, we have made the following changes:

- Added the `modeCryptoList` condition to the `showNumbersRule` Pipe to handle number rules for USD display value.
- Modified the calling code to pass `false` for `modeCryptoList` when using the `showNumbersRule` Pipe with USD values.

## Changes Made

- Modified the `showNumbersRule` Pipe to incorporate the `modeCryptoList` condition when processing USD values.
- Updated the calling code to pass `false` for `modeCryptoList` when using the `showNumbersRule` Pipe with USD values.


## Notes for Reviewers

- Kindly review the changes made to ensure that the `showNumbersRule` Pipe correctly handles number rules for USD display value based on the `modeCryptoList` condition, and that the calling code passes `false` for `modeCryptoList` in the USD value case.
- If there are alternative approaches or suggestions to improve the implementation, please feel free to provide feedback.

Thank you for your time and consideration. Your feedback and suggestions are highly appreciated.

Best regards,
Louay HICHRI