### PR TITLE
remove provider array for auth module

### DIFF
--- a/src/app/auth/authentication.module.ts
+++ b/src/app/auth/authentication.module.ts
@@ -1,16 +1,5 @@
 import { NgModule } from '@angular/core';
-import { AsyncPipe } from '@angular/common';
 import { AuthenticationRoutingModule } from '@app/auth/authentication-routing.module';
-import { CookieService } from 'ngx-cookie-service';
-import { TranslateService } from '@ngx-translate/core';
-import { ToastrService } from 'ngx-toastr';
-import { AuthService } from '@core/services/Auth/auth.service';
-import { TokenStorageService } from '@core/services/tokenStorage/token-storage-service.service';
-import { AuthGuardService } from '@core/services/auth-guard.service';
-import { ContactService } from '@core/services/contact/contact.service';
-import { FilesService } from '@core/services/files/files.Service';
-import { ContactMessageService } from '@core/services/contactmessage/contact-message.service';
-import { ProfileService } from '@core/services/profile/profile.service';
 import { CountdownModule } from 'ngx-countdown';
 import { HttpClientModule } from '@angular/common/http';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -39,20 +28,6 @@ import { ResetPasswordComponent } from '@app/auth/components/reset-password/rese
     FormsModule,
     ReactiveFormsModule.withConfig({ warnOnNgModelWithFormControl: 'never' }),
     CustomFormsModule
-  ],
-
-  providers: [
-    CookieService,
-    TranslateService,
-    ToastrService,
-    AuthService,
-    TokenStorageService,
-    AuthGuardService,
-    AsyncPipe,
-    ContactService,
-    FilesService,
-    ContactMessageService,
-    ProfileService
   ]
 })
 export class AuthenticationModule {}


### PR DESCRIPTION
## PR Description

Hey team,

This PR focuses on improving the structure and maintainability of our authentication module in the Angular app. Currently, the auth module directly calls providers for services instead of utilizing dependency injection. To address this, we have made the following changes:

- Removed direct provider calls for services from the auth module.

## Changes Made

- Removed direct provider calls for services from the auth module.

## Notes for Reviewers

- Kindly review the changes made to ensure that the auth module no longer directly calls providers for services and correctly uses dependency injection.
- Ensure that the required services are properly injected into the auth module.
- If there are alternative approaches or suggestions to further improve the implementation, please feel free to provide feedback.

Thank you for your time and consideration. Your feedback and suggestions are highly appreciated.

Best regards,
Louay HICHRI