### PR TITLE
check for campaign budget to activate the refund option

### DIFF
--- a/src/app/campaigns/campaign-details/components/campaign-detail/campaign-detail.component.html
+++ b/src/app/campaigns/campaign-details/components/campaign-detail/campaign-detail.component.html
@@ -444,7 +444,7 @@
           
           id="btn-edit-refunds-pool"
           (click)="getRefunds(campaign.id)"
-          *ngIf="campaign.isOwnedByUser && campaign.type === 'finished'  && !loadingData"
+          *ngIf="campaign.isOwnedByUser && campaign.type === 'finished'  && !loadingData && campaign.budget !== '0'"
           >
           <p *ngIf="refundButtonDisable">
             <img src="../../../../../assets/Images/Vector-loading.svg"/>


### PR DESCRIPTION
## PR Description
Hey team,

This pull request addresses an issue where the "Retrieve Budget" button is displayed even when a campaign has a budget of zero dollars. The proposed solution involves adding a condition in the *ngIf directive to check if the campaign's budget is not equal to zero before rendering the button. This enhancement ensures a better user experience by hiding the button for campaigns with no available budget.


## Changes Made
- Identified the relevant section of the code responsible for rendering the "Retrieve Budget" button.
- Added a condition in the *ngIf directive to check if the campaign's budget is not equal to zero.
- Tested the changes to verify that the button is correctly hidden for campaigns with zero dollars on the budget.
- Ensured that the button remains visible for campaigns with a non-zero budget, allowing users to retrieve the budget when available.


## Notes for Reviewers
Please review the changes made in this pull request carefully, focusing on the modification in the *ngIf condition for hiding the "Retrieve Budget" button. Any feedback, suggestions, or improvements are welcome, and I will address them promptly.

Best regards,
Louay HICHRI