### PR TITLE
Remove transaction hash when you apply in campaign in notification

### DIFF
--- a/src/app/notifications/notification.component.html
+++ b/src/app/notifications/notification.component.html
@@ -152,8 +152,7 @@
                 <span
                   *ngIf="i.type === 'apply_campaign'"
                   class="link"
-                  [translate]="'apply_campaign_hash'"
-                  [translateParams]="{ hash: i._params.hash }"
+                
                 ></span>
                 <span
                   *ngIf="i.type === 'transfer_event'"

--- a/src/app/notifications/notification.component.ts
+++ b/src/app/notifications/notification.component.ts
@@ -729,9 +729,7 @@ export class NotificationComponent implements OnInit {
     }
     if (notif?.label?.cmp_hash && notif?.label?.linkHash) {
       // console.log(notif?.label?.promHash)
-      this.router.navigate(['home/campaign', notif.label.cmp_hash], {
-        queryParams: { linkHash: notif?.label?.linkHash, type: 'earnings' }
-      });
+      this.router.navigate(['home/farm-posts']);
     }
 
     if (notif.label.network === 'eth') {

--- a/src/app/notifications/notification.component.ts
+++ b/src/app/notifications/notification.component.ts
@@ -694,9 +694,7 @@ export class NotificationComponent implements OnInit {
     if (notif?.label?.txhash) {
       this.hashLink(notif?.label?.network, notif?.label?.txhash);
     } else if (notif?.label?.cmp_hash) {
-      this.router.navigate(['home/campaign', notif.label.cmp_hash], {
-        fragment: notif.label.cmp_hash
-      });
+      this.router.navigate(['home/farm-posts']);
     } //if the notification has cmp_has it will redirect to campaign detail component
 
     // if (notif?.label?.transactionHash) {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -983,7 +983,7 @@
   "apply_form.update_profile": "Edit my profile",
   "apply_form.verify_information": "Please check this informations",
   "apply_form.youtube_alert": "You must enter the address of your Youtube channel before you can apply.",
-  "apply_campaign": "You have applied in the following campaign: {{title}}. hash: ",
+  "apply_campaign": "You have applied in the following campaign: {{title}}",
   "apply_campaign_hash": "{{hash}}",
   "cmp_candidate_accept_link_hash": "{{hash}}",
   "asked_cryptoCurrency": "{{name}} ask you {{nbr}} {{crypto}}",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -269,7 +269,7 @@
   "apply_form.not_specified": "Non renseigné",
   "apply_form.verify_information": "Merci de vérifier ces informations",
   "apply_form.youtube_alert": "Vous devez renseigner l'adresse de votre chaîne Youtube avant de pouvoir postuler.",
-  "apply_campaign": "Vous avez postulé à la campagne suivante:{{title}}. hash: {{hash}}",
+  "apply_campaign": "Vous avez postulé à la campagne suivante:{{title}}",
   "apply_campaign_hash": "{{hash}}",
   "cmp_candidate_accept_link_hash": "{{hash}}",
   "asked_cryptoCurrency": "{{name}} vous demande {{nbr}}",


### PR DESCRIPTION
### **Title: Feature**: Remove Hash Transaction from Notifications and Redirect to Farm Posts

**### Description:**
This pull request introduces an enhancement to improve the user experience by removing the hash transaction from notifications and redirecting users directly to farm posts. The following changes have been made:

1. Notification Modification: Hash transactions are no longer displayed in notifications. Instead, a concise and user-friendly message is presented to users, providing them with relevant information about their activities.

2. Redirect to Farm Posts: When users click on a notification, they are now redirected directly to the corresponding farm post. This improvement saves users time and effort by taking them directly to the relevant information they are seeking.


Thank you for your time and consideration.
Best regards,
Rania Morheg