### PR TITLE
remove the sattbep20 force in create camapign

### DIFF
--- a/src/app/campaigns/components/password-modal/password-modal.component.ts
+++ b/src/app/campaigns/components/password-modal/password-modal.component.ts
@@ -330,8 +330,7 @@ export class PasswordModalComponent implements OnInit {
     let campaign_info = this.fillInformations();
     this.showButtonSend = false;
     this.loadingButton = true;
-    let tokenSymbol =
-      (token === 'BNB' && 'SATTBEP20') || this.campaign.currency.name;
+    let tokenSymbol = this.campaign.currency.name;
     TokenOBj.pass = campaign_info.pass;
     TokenOBj.walletaddr = this.tokenStorageService.getIdWallet();
     TokenOBj.addr = ListTokens[tokenSymbol].contract;
@@ -592,6 +591,7 @@ export class PasswordModalComponent implements OnInit {
   }
 
   launchCampaignWithPerPerformanceReward(campaign_info: any) {
+    if(campaign_info.currency === 'BNB') campaign_info.tokenAddress = null;
     return this.campaignService.createCompaign(campaign_info).pipe(
       tap(() => {
         this.gasError = false;


### PR DESCRIPTION
## PR Description
Hey team,

This PR aims to improve the frontend functionality by removing the check for token symbol in our application. Currently, there is a condition in place that checks if the token is BNB and then switches to SATTBEP20. However, this PR proposes removing this condition to simplify the codebase and improve flexibility.

## Changes Made
- Removed the token symbol check from the frontend code.
- Updated the BNB switching mechanism to remove the condition related to the token symbol.

## Notes for Reviews
- Please review the changes made to ensure that the removal of the token symbol check and the corresponding BNB switching modification do not introduce any unintended issues.
- Verify that the application functions correctly without the token symbol check and that the BNB switching mechanism operates as intended.
- If you have any alternative suggestions or further improvements to propose, please provide your valuable feedback.


Thank you for your attention and contributions. Your feedback and suggestions are highly appreciated.

Best regards,
Louay HICHRI