### PR TITLE
Update Volume 24h to Market Cap Value

### DIFF
--- a/src/app/wallet/components/crypto-info/crypto-info.component.ts
+++ b/src/app/wallet/components/crypto-info/crypto-info.component.ts
@@ -96,7 +96,7 @@ export class CryptoInfoComponent implements OnInit, AfterViewInit {
           let arrayOfObs = [];
           arrayOfObs.push(
             this.cryptoInfoService
-              .getCryptoInfoById(res.id, 'usd')
+              .getCryptoInfoById(res?.id, 'usd')
               .pipe(map((res: any) => res[0]))
           );
           arrayOfObs.push(

--- a/src/app/wallet/components/crypto-info/crypto-info.component.ts
+++ b/src/app/wallet/components/crypto-info/crypto-info.component.ts
@@ -51,7 +51,7 @@ export class CryptoInfoComponent implements OnInit, AfterViewInit {
   state = {
     current: 'black'
   };
-  selectedPeriod: string = '1';
+  selectedPeriod: string = 'max';
   dataY = [1, 10, 20, 30];
   marketCap: any;
   marketCapFD: any;

--- a/src/app/wallet/components/crypto-market-cap/crypto-market-cap.component.html
+++ b/src/app/wallet/components/crypto-market-cap/crypto-market-cap.component.html
@@ -45,7 +45,7 @@
           <th scope="col d-none d-sm-block">1H%</th>
           <th scope="col">24H%</th>
           <th scope="col d-none d-sm-block">{{ 'Cryptolist.7d' | translate }}</th>
-          <th scope="col d-none d-sm-block">{{ 'Cryptolist.volume' | translate }}</th>
+          <th scope="col d-none d-sm-block">{{ 'Cryptolist.marketcap' | translate }}</th>
           <th scope="col d-none d-sm-block">{{ 'Cryptolist.last7d' | translate }}</th>
         </tr>
       </thead>
@@ -106,7 +106,7 @@
                crypto[1]?.percent_change_7d | number: '1.0-2'
             }}%
           </td>
-          <td class="align-middle">{{  crypto[1]?.volume_24h | currency:'USD':'symbol':'1.0-0' }}</td>
+          <td class="align-middle">{{  crypto[1]?.market_cap | currency:'USD':'symbol':'1.0-0' }}</td>
         <ng-container *ngIf="sparklineIn7dCryptoList[i]"> 
             <td>
         

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -316,7 +316,7 @@
 "Cryptolist.title.mobile":"Top Cryptocurrencies",
 "Cryptolist.description.mobile":"Explore the Best Market Options and Maximize Your Investments!",
 "Cryptolist.7d":"7D%",
-"Cryptolist.volume":"VOLUME(24H)",
+"Cryptolist.marketcap":"MARKET CAP",
 "Cryptolist.last7d":"LAST 7DAYS",
   "Cryptolist.name": "NAME",
   "Cryptolist.token": "TOKEN",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -620,7 +620,7 @@
   "Cryptolist.title.mobile": "Principales Cryptomonnaies",
   "Cryptolist.description.mobile": "Explorez les Meilleures Options du marché et Maximisez Vos Investissements !",
   "Cryptolist.7d": "7j%",
-  "Cryptolist.volume": "VOLUME(24H)",
+  "Cryptolist.marketcap": "MARKET CAP",
   "Cryptolist.last7d": "7DERNIERS JOURS",
   "Cryptolist.name": "NOM",
   "Cryptolist.token": "TOKEN",


### PR DESCRIPTION
Dear team,

This PR introduces a significant update to the volume 24h column in our cryptocurrency table. We have made the following change:

**Update Volume 24h to Market Cap Value:** We have modified the volume 24h column in the table to display the market capitalization value for each cryptocurrency instead. This change provides users with more valuable information about the size and value of each cryptocurrency in the market. By presenting the market capitalization instead of the volume 24h, we enhance the understanding and analysis of cryptocurrencies' relative worth.
Reviewers, please carefully review this change and ensure that the volume 24h column has been correctly updated to reflect the market capitalization value for each cryptocurrency. Your feedback, suggestions, and alternative approaches to further improve this implementation are highly appreciated.

Thank you for your attention to detail and your dedication to delivering an informative and user-friendly platform.

Best regards,
Rania Morheg