### PR TITLE
add the case of video on instagram post

### DIFF
--- a/src/app/campaigns/components/farm-post-card/farm-post-card.component.html
+++ b/src/app/campaigns/components/farm-post-card/farm-post-card.component.html
@@ -44,12 +44,19 @@
         onerror="this.src='/assets/Images/campagne/twitter_cover.svg'"
         class="cmp-img2"
       />
-      <img
-        *ngIf="prom.typeSN === 3"
+      <ng-container  *ngIf="prom.typeSN === 3 && prom.mediaUrl.includes('mp4')">
+        <video [src]="prom.mediaUrl" autoplay loop [muted]="true"></video>
+      </ng-container>
+
+      <ng-container  *ngIf="prom.typeSN === 3 && !prom.mediaUrl.includes('mp4')">
+        <img
         [src]="prom.mediaUrl"
         onerror="this.src='/assets/Images/campagne/instagramm.svg'"
         class="cmp-img2"
       />
+      </ng-container>
+      
+      
       <img
         *ngIf="prom.typeSN === 5"
         [src]="prom.mediaUrl"


### PR DESCRIPTION
## PR Description:

Hello team,

This PR targets an issue within our frontend application, which arose when a user posted a link to a video on Instagram. Previously, our frontend code only accommodated for image media, leading to errors when handling video content.

To resolve this, we've implemented a check within our frontend code to identify the type of media associated with the link. If the link includes the term 'mp4', we pass it as a source to a video HTML tag. If it doesn't include 'mp4', we continue handling it as an image, passing it to an img HTML tag.

## Changes Made:

- Implemented a check to identify if a media link is pointing to a video file (by looking for 'mp4' within the link).
- Updated our frontend rendering to appropriately use video or img HTML tags based on the media type detected.


## Notes for Reviewers:

Please review these changes, focusing on the implementation of the media type check and the associated changes in how we render media on the frontend. Ensure these changes haven't introduced any unintended issues and that the application now correctly handles both image and video media types.

Your attention and contributions are always appreciated. Your feedback and suggestions are highly valuable.

Best regards,
Louay HICHRI