### PR TITLE
add og tag for campagin details

### DIFF
--- a/src/app/campaigns/campaign-details/components/campaign-details-container/campaign-details-container.component.html
+++ b/src/app/campaigns/campaign-details/components/campaign-details-container/campaign-details-container.component.html
@@ -1,4 +1,10 @@
 
+<head>
+  <meta property="og:title" content="{{ campaign.title}}" />
+  <meta property="og:description" content="{{ campaign.summary }}" />
+  <meta property="og:image" content="{{ ogImageUrl }}" />
+</head>
+
 <ng-container *ngIf="campaign?.id === campaignId; else loading">
   <div class="content" style="min-height: 50vh">
     <router-outlet></router-outlet>

--- a/src/app/campaigns/campaign-details/components/campaign-details-container/campaign-details-container.component.ts
+++ b/src/app/campaigns/campaign-details/components/campaign-details-container/campaign-details-container.component.ts
@@ -9,6 +9,7 @@ import { Meta } from '@angular/platform-browser';
 import { environment } from '@environments/environment';
 import { sattUrl } from '@config/atn.config';
 import { isPlatformServer } from '@angular/common';
+import { ipfsURL } from '@config/atn.config';
 
 @Component({
   selector: 'app-campaign-details-container',
@@ -18,6 +19,7 @@ import { isPlatformServer } from '@angular/common';
 export class CampaignDetailsContainerComponent implements OnInit {
   showInfoSpinner: boolean = true;
   showmoonboy: boolean = false;
+  ogImageUrl: any;
 
   campaign$!: Observable<Campaign>;
   campaign: any;
@@ -140,15 +142,17 @@ export class CampaignDetailsContainerComponent implements OnInit {
 
     this.campaign$.pipe(takeUntil(this.isDestroyed)).subscribe((campaign) => {
       this.campaign = campaign;
+     
       setTimeout(() => {
         this.showmoonboy = campaign.id === this.campaignId;
       }, 1000);
-
+      this.ogImageUrl = campaign.coverSrcMobile.includes('ipfs') ? ipfsURL + campaign.coverSrcMobile.substring(27, campaign.coverSrcMobile.length) : campaign.coverSrcMobile;
+      
 
       this.meta.updateTag(
         {
           itemprop: 'image',
-          content: `${sattUrl}/campaign/coverByCampaign/${campaign.id}`
+          content: this.ogImageUrl
         },
         `itemprop='image'`
       );
@@ -181,21 +185,27 @@ export class CampaignDetailsContainerComponent implements OnInit {
       this.meta.updateTag(
         {
           name: 'og:image:secure_url',
-          content: `${sattUrl}/campaign/coverByCampaign/${campaign.id}`
+          content: this.ogImageUrl
         },
         `name='og:image:secure_url'`
       );
 
       this.meta.updateTag(
         {
-          name: 'og:image',
-          content: `${sattUrl}/campaign/coverByCampaign/${campaign.id}`
+          property: 'og:image',
+          content: this.ogImageUrl
         },
-        `name='og:image'`
+        `property='og:image'`
       );
 
 
-
+      this.meta.updateTag(
+        {
+          name: 'og:image',
+          content: this.ogImageUrl
+        },
+        `name='og:image'`
+      );
       this.meta.updateTag(
         {
           property: 'og:image:width',
@@ -266,7 +276,7 @@ export class CampaignDetailsContainerComponent implements OnInit {
       this.meta.updateTag(
         {
           name: 'twitter:image',
-          content: `https://satt-token.com/assets/img/share_img_200px.png`
+          content: this.ogImageUrl
         },
         `name='twitter'`
       );


### PR DESCRIPTION
This PR addresses the issue of missing Open Graph (OG) tags in the metadata of our website, specifically when sharing campaign links on social media platforms. Currently, when sharing links from the website "https://dapp.satt.com/campaign" the link previews on social media platforms do not display the desired information.

To resolve this issue, the following changes have been made:

**Adding Open Graph (OG) Tags**: We have implemented the addition of Open Graph (OG) tags to the metadata of our website. These tags provide social media platforms with structured information about the shared links, enabling them to generate accurate and informative link previews. By including OG tags, we ensure that the desired information is displayed correctly when our campaign links are shared on social media.
These changes aim to improve the link preview experience when sharing campaign links from our website on social media platforms. Reviewers, please verify that the OG tags have been added correctly to the website's metadata and that they generate accurate link previews on social media. Your feedback, suggestions, and alternative approaches to further enhance the usage of OG tags are highly appreciated.

Thank you for your time and dedication to delivering an improved sharing experience for our users.

Best regards,
Rania Morheg






