### PR TITLE
remove authgard in campain-details

### DIFF
--- a/src/app/campaigns/campaign-details/components/campaign-detail/campaign-detail.component.ts
+++ b/src/app/campaigns/campaign-details/components/campaign-detail/campaign-detail.component.ts
@@ -216,9 +216,7 @@ export class CampaignDetailComponent implements OnInit {
   }
   ngOnInit(): void {
     this.getScreenWidth = window.innerWidth;
-    this.walletFacade.verifyUserToken().subscribe((res:any) => {
-      if(res?.message != "success") this.expiredSession();
-    })
+   
     this.refundButtonDisable = true;
     this.loadingData = true;
     this.CampaignService.isLoading.subscribe((res) => {
@@ -320,9 +318,7 @@ export class CampaignDetailComponent implements OnInit {
       this.loadingButton = true;
       this.CampaignService.getRefunds(this.campaign.hash, this.passwordForm.value.password, this.campaign.currency.type).subscribe(
         (res: any) => {
-          if(res?.name === "JsonWebTokenError") {
-            this.expiredSession();
-          } else {
+          
             if(res.code === 200 && res.message === "budget retrieved") {
               this.loadingButton = false;
               this.successMessage = "Budget retrieved";
@@ -330,7 +326,7 @@ export class CampaignDetailComponent implements OnInit {
                 this.closeModal(this.transactionPassword)
               }, 3000)
             }
-          }
+     
           
         },
         (err) => {
@@ -416,14 +412,11 @@ export class CampaignDetailComponent implements OnInit {
     )
       .pipe(takeUntil(this.isDestroyed))
       .subscribe((data: any) => {
-        if(data?.name === "JsonWebTokenError") {
-          
-          this.expiredSession();
-        } else {
+       
           if (data.message === 'success') {
             this.allProms = data.data.allProms;
           }
-        }
+       
       });
   }
 
@@ -874,12 +867,10 @@ export class CampaignDetailComponent implements OnInit {
         takeUntil(this.isDestroyed)
       )
       .subscribe((data1: any) => {
-        if(data1?.name === "JsonWebTokenError") {
-          this.expiredSession();
-        } else {
+     
           this.toastr.success(data1);
           this.router.navigate(['home/ad-pools']);
-        }
+      
         
       });
   }


### PR DESCRIPTION
Dear team,

This PR proposes the removal of the authgard (authentication guard) in the campaign-details component. The following changes have been made:

Removal of Authgard: We have removed the authgard from the campaign-details component. This change allows unrestricted access to the campaign details for all users, irrespective of their authentication status. By removing the authentication guard, we aim to provide a more inclusive and seamless experience when accessing campaign details.
Reviewers, please verify that the authgard has been successfully removed from the campaign-details component. Ensure that the desired behavior is achieved, allowing unrestricted access to the campaign details. Your feedback, suggestions, and alternative approaches to authentication and authorization in the campaign-details component are welcome.

Thank you for your attention to detail and your dedication to improving our platform's accessibility.

Best regards,
Rania Morheg