### PR TITLE
using the tokenStorageService to get the result of isNewUser in the n…

### DIFF
--- a/src/app/campaigns/components/campaigns-dashboard/campaigns-dashboard.component.ts
+++ b/src/app/campaigns/components/campaigns-dashboard/campaigns-dashboard.component.ts
@@ -1,5 +1,5 @@
 /* eslint-disable prettier/prettier */
-import { ChangeDetectorRef,Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { NavigationEnd, Router } from '@angular/router';
 import { CampaignsDashboardService } from '@campaigns/services/campaigns-dashboard.service';
@@ -9,7 +9,6 @@ import { TokenStorageService } from '../../../core/services/tokenStorage/token-s
 import { sattUrl } from '@config/atn.config';
 import { WalletService } from '@app/core/services/wallet/wallet.service';
 import { data } from 'jquery';
-
 
 @Component({
   selector: 'app-campaigns-dashboard',
@@ -38,20 +37,13 @@ export class CampaignsDashboardComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-
-    if(!this.tokenStorageService.getIsAuth()){
-
-
-      this.isNewUser= 'true';
-    }else
-    if(this.tokenStorageService.getNewUserV2() == null ){
-
-      this.isNewUser= 'true';
+    if (!this.tokenStorageService.getIsAuth()) {
+      this.isNewUser = 'true';
+    } else if (this.tokenStorageService.getNewUserV2() == null) {
+      this.isNewUser = 'true';
+    } else {
+      this.isNewUser = this.tokenStorageService.getNewUserV2();
     }
-    else{
-
-       this.isNewUser = this.tokenStorageService.getNewUserV2()
-    }  
     this.requestedPathUrlChanges$
       .pipe(takeUntil(this.isDestroyed))
       .subscribe((url: string) => {
@@ -63,5 +55,4 @@ export class CampaignsDashboardComponent implements OnInit {
     this.isDestroyed.next('');
     this.isDestroyed.unsubscribe();
   }
-
 }


### PR DESCRIPTION
### **Commit Review:**
Commit: "Handle the isNewUser variable in ngOnint to prevent the banner from displaying correctly"

### **Description:**
This commit addresses the issue where the "reminder" banner briefly appears when connecting or refreshing the AdPools page. The problem has been resolved by utilizing the tokenStorageService to retrieve the value of isNewUser in the ngOnInit method. By checking the variable in ngOnInit, the page now displays correctly, and the user will not see the unwanted banner.

### **Changes Made:**

Introduced usage of tokenStorageService to retrieve the value of isNewUser.
Utilized the value of isNewUser to conditionally display the appropriate banner content.
Updated the HTML code for the banner to include two ng-container blocks based on the value of isNewUser.
Summary for Reviewers:
Please review the following aspects of this commit:

### **Implementation of isNewUser Handling:**

Verify the integration of tokenStorageService to retrieve the value of isNewUser.
Evaluate the usage of the retrieved value to conditionally display the correct banner content.
Banner Display:

Test the AdPools page by connecting or refreshing to ensure the banner no longer briefly appears.
Confirm that the correct banner is displayed based on the value of isNewUser.
Translation and HTML Updates:

Review the translation keys used for the banner titles and descriptions to ensure they are accurate.
Check the HTML code to ensure the appropriate CSS classes and routing links are applied.
Your feedback, suggestions, and alternative approaches are welcome to further enhance these changes and improve the overall user experience on the AdPools page.

_Thank you for your time and consideration. Your feedback is highly appreciated._

Best regards,

SKANDER KHABOU
SATT Team