### PR TITLE
fix quta crypto market cap

### DIFF
--- a/src/app/core/services/wallet/cryptofetch-service.service.ts
+++ b/src/app/core/services/wallet/cryptofetch-service.service.ts
@@ -34,13 +34,14 @@ export class CryptofetchServiceService {
    
     
   }
-  getCryptoPriceDetails(cryptoList: number[]): Observable<any> {
+  getCryptoPriceDetails(cryptoList: number[]) {
+
     // Converting array to comma-separated string
     const cryptoListString = cryptoList.join(',');
 
     // Configuring the HTTP params
     const params = new HttpParams().set('cryptolist', cryptoListString);
-
+   
     // Making the HTTP GET request
     return this.http.get( sattUrl + '/wallet/cryptoPriceDetails', { params });
   }

--- a/src/app/wallet/components/crypto-market-cap/crypto-market-cap.component.ts
+++ b/src/app/wallet/components/crypto-market-cap/crypto-market-cap.component.ts
@@ -78,24 +78,35 @@ private ngUnsubscribe = new Subject<void>();
           }
         });
     
-        const chunks = this.getArrayChunks(this.filteredCryptoListId, 10);
+        const chunks = this.getArrayChunks(this.filteredCryptoListId, 50);
+       
+     
+        
         return forkJoin(chunks.map(chunk => this.fetchservice.getCryptoPriceDetails(chunk)));
       })
     ).subscribe(
-      (data: any[]) => { 
-        data.forEach((response: any) => {
-          const details = response?.data || [];
+      (data: any) => { 
+   
+       
+        const dataArray = Object.values(data)
+    
+        dataArray.forEach((response: any) => {
+          
+          const details = Object.values(response?.data) || [];
           details.forEach((crypto: any) => {
             if (crypto) {
               this.sparklineIn7dCryptoList.push(crypto.sparkline_in_7d);
             }
           });
         });
-    
+   
       },
       (error) => {
+    
+        
         console.error(error);
       }
+      
     );
 
     this.fetchservice.getGlobalCryptoMarketInfo().pipe(takeUntil(this.ngUnsubscribe)).subscribe((res: any) => {


### PR DESCRIPTION
Dear team,

This PR addresses an adjustment to the crypto market cap quota chunk size. The following change has been made:

Fixing Crypto Market Cap Quota Chunk Size: We have modified the chunk size for the crypto market cap quota from 10 to 50. This adjustment allows for a larger number of market cap data points to be processed and retrieved within the specified quota limits. By increasing the chunk size, we improve the efficiency of retrieving market cap data and enhance the overall performance of our platform.
Reviewers, please verify that the chunk size for the crypto market cap quota has been successfully updated to 50. Ensure that the adjustment aligns with the specified quota limits and improves the retrieval of market cap data. Your feedback, suggestions, and alternative approaches to further optimize the chunk size or manage the market cap quota are welcome.

Thank you for your attention to detail and your dedication to delivering an optimized platform.

Best regards,
Rania Morheg