### PR TITLE
Modify the sign-in error message when the account does not exist

### DIFF
--- a/src/app/auth/components/authentication/authentication.component.ts
+++ b/src/app/auth/components/authentication/authentication.component.ts
@@ -641,11 +641,9 @@ getCookie(key: string){
           takeUntil(this.onDestroy$),
           catchError((error: HttpErrorResponse) => {
 
-            if (
-              error.error.message.startsWith('ValidationError') 
-              //=== 'ValidationError: "password" failed custom validation because password not match'
-            ) {
+            if(error.error.message=='ValidationError: "password" failed custom validation because password not match'){
               this.errorMessage = 'incorrectPassword';
+              
             } else if (error.error.error.message === 'user not found') {
               this.errorMessage = 'RegisterFirst';
 


### PR DESCRIPTION
Dear team,

I wanted to inform you that I have made some updates to our application. Specifically, I have modified the sign-in error message when the account does not exist.

Here are the details of the modification:
Modify sign-in error message when the account does not exist

welcome your feedback and suggestions regarding this modification as we continuously strive to enhance the user experience of our application.

Thank you for your attention and collaboration.

Best regards,
Ben Marzouka Gamra