### PR TITLE
fix association threads button

### DIFF
--- a/src/app/user-settings/components/social-networks/social-networks.component.html
+++ b/src/app/user-settings/components/social-networks/social-networks.component.html
@@ -1105,7 +1105,7 @@
           class="tiktok-btn-cnx"
           [className]="isLoading ? 'center-div' : 'tiktok-btn-cnx'"
           (click)="addThreadsAccount()"
-        
+          *ngIf="checkThreadsExist"
         >
           <ng-container *ngIf="!isLoading">
             <img src="./assets/Images/threads-logo.svg" width="24px" />

--- a/src/app/user-settings/components/social-networks/social-networks.component.ts
+++ b/src/app/user-settings/components/social-networks/social-networks.component.ts
@@ -85,10 +85,10 @@ export class SocialNetworksComponent implements OnInit {
   ) { }
   ngOnInit(): void {
     this.socialAccountFacadeService.dispatchUpdatedSocailAccount();
-    this.socialAccountFacadeService.checkThreads().subscribe((res:any) => {
-      if(res.message === true) this.checkThreadsExist = true
-      else this.checkThreadsExist = false;
-    });
+    // this.socialAccountFacadeService.checkThreads().subscribe((res:any) => {
+    //   if(res.message === true) this.checkThreadsExist = true
+    //   else this.checkThreadsExist = false;
+    // });
     this.getSocialNetwork();
 
     // this.profilService.getTiktokProfilPrivcay().subscribe((res:any)=>
@@ -159,6 +159,7 @@ export class SocialNetworksComponent implements OnInit {
       )
       .subscribe(({ params, data }: { params: Params; data: any }) => {
         if (data !== null) {
+        
           let count = 0;
           this.allChannels = data;
           this.channelGoogle = data.google;
@@ -168,7 +169,7 @@ export class SocialNetworksComponent implements OnInit {
 
           this.channelTiktok = data.tikTok;
           this.setUrlMsg(params, data);
-
+          this.checkTheradsAccountExit(data)
           if (this.channelGoogle?.length !== 0) {
             count++;
           } else {
@@ -227,8 +228,16 @@ export class SocialNetworksComponent implements OnInit {
         }
       });
   }
+  checkTheradsAccountExit(data:any)
+  {     
+    this.checkThreadsExist = data.facebook.some((elem : any) => elem.threads_id )      
+   }  
+  
   //get errors from url
+ 
   setUrlMsg(p: Params, data: IGetSocialNetworksResponse): void {
+    
+    
     if (p.message) {
       if (p.message === 'access-denied') {
         this.errorMessage = 'access-cancel';
@@ -398,7 +407,7 @@ export class SocialNetworksComponent implements OnInit {
       this.socialAccountFacadeService.deleteThreadAccount(this.threadIdToDelete).subscribe((response:any) => {
         if (response.message === 'deleted successfully') {
           this.socialAccountFacadeService.dispatchUpdatedSocailAccount();
-          this.checkThreadsExist = true;
+      
           //this.getSocialNetwork();
           this.closeModal(id);
         }
@@ -482,7 +491,7 @@ export class SocialNetworksComponent implements OnInit {
     this.socialAccountFacadeService.addThreads().subscribe((res:any) => {
       if(res.message === 'threads_account_added') {
         this.isLoading = false;
-        this.checkThreadsExist = false;
+    
         const index = this.channelFacebook.findIndex((obj:any) => obj.instagram_username === res.data.username);
         if(index !== -1) {
           let newObj = {


### PR DESCRIPTION
Dear team,

This PR addresses the association of the Oracle Threads button and removes the condition related to the Instagram count. The following changes have been made:

Fixing Oracle Threads Association: We have resolved the issue with the Oracle Threads button association. The button is now correctly linked to the Oracle Threads feature, ensuring that users can seamlessly utilize external data sources and APIs within their campaigns.

Removing Instagram Count Condition: We have removed the condition related to the Instagram count. This change allows users to access the Oracle Threads feature without any restrictions based on the presence or absence of an Instagram count.

By making these adjustments, we provide a smoother and more intuitive user experience, enabling users to access Oracle Threads functionality without any unnecessary conditions.

Reviewers, please verify that the Oracle Threads button is correctly associated with the feature and that the condition based on the Instagram count has been successfully removed. Ensure that users can easily access and utilize the Oracle Threads feature. Your feedback, suggestions, and alternative approaches to further optimize the Oracle Threads integration are highly appreciated.

Thank you for your time and effort in enhancing the functionality and accessibility of our platform.

Best regards,
Rania Morheg






