### PR TITLE
afficher la totalité du texte : en français → Migrer les Tokens

### DIFF
--- a/src/app/wallet/components/migration/migration.component.scss
+++ b/src/app/wallet/components/migration/migration.component.scss
@@ -204,7 +204,7 @@
 .next-step {
   background: #4048ff;
   border-radius: 30px;
-  width: 150px;
+  width: 200px;
   height: 5.3vh;
   border: 0;
   font-family: 'Poppins';


### PR DESCRIPTION
In this pull request, I have implemented updates to the text display functionality in two languages:

English: The text will now be displayed as "Migret Tokens" to represent the complete content.

French: The text will now be displayed as "Migrer les Tokens" to signify the full content.

And i change the width of this button from 170px to 200px to make all the texte are clear to see 
