### PR TITLE
 fix add facebook account without page

### DIFF
--- a/src/app/user-settings/components/social-networks/social-networks.component.ts
+++ b/src/app/user-settings/components/social-networks/social-networks.component.ts
@@ -247,7 +247,7 @@ export class SocialNetworksComponent implements OnInit {
  
   setUrlMsg(p: Params, data: IGetSocialNetworksResponse): void {
     
-    
+
     if (p.message) {
       if (p.message === 'access-denied') {
         this.errorMessage = 'access-cancel';
@@ -290,7 +290,8 @@ export class SocialNetworksComponent implements OnInit {
           this.errorMessage = 'account_linked_other_account';
           this.router.navigate(['/home/settings/social-networks']);
         }, 3000);
-      } else if (p.message === 'page already exists') {
+      } 
+      else if (p.message === 'page already exists') {
         this.errorMessage = 'page already exists';
         setTimeout(() => {
           // this.ngOnInit();
@@ -298,6 +299,13 @@ export class SocialNetworksComponent implements OnInit {
           this.router.navigate(['/home/settings/social-networks']);
         }, 3000);
       }
+      else if (p.message === 'required_page') {
+
+        setTimeout(() => {
+          this.errorMessage = 'no_page_selected';
+          this.router.navigate(['/home/settings/social-networks']);
+        }, 3000);
+      } 
     }
   }
 


### PR DESCRIPTION
Dear team,

This PR addresses two issues related to adding a Facebook account and error messaging. The following changes have been made:

Fixing Adding Facebook Account Without Page: We have resolved the issue where adding a Facebook account without a linked page was causing errors. The fix ensures that users can successfully add a Facebook account even if there is no associated page.

Error Message Enhancement: We have improved the error message "No page was selected!" to provide more context and guidance to users. The enhanced message offers clear information about the issue and how to proceed, enhancing the user experience.

By making these adjustments, we ensure smoother interaction with Facebook account linking and provide more helpful error messaging.

Reviewers, please verify that users can now add Facebook accounts without pages and that the error message "No page was selected!" has been effectively improved. Test the interactions and error scenarios to ensure that the user experience is enhanced. Your feedback, suggestions, and alternative approaches to further optimize the Facebook account linking and error messaging are highly appreciated.

Thank you for your attention to detail and your dedication to delivering a seamless and user-friendly platform.

Best regards,
Rania Morheg