### PR TITLE
feed/reset filter issues

### DIFF
--- a/src/app/notifications/notification.component.html
+++ b/src/app/notifications/notification.component.html
@@ -117,6 +117,7 @@
                 checkbck: checkbox.toggle,
                 checkb: !checkbox.toggle
               }"
+              [checked]="checkbox.toggle"
               (click)="enableDisableRulecheck(checkbox)"
             />
             <label class="checkb">{{ checkbox.label | translate }}</label>
@@ -164,7 +165,9 @@
                 checkbck: checkbox.toggle,
                 checkb: !checkbox.toggle
               }"
+              [checked]="checkbox.toggle"
               (click)="enableDisableRulecheck(checkbox)"
+ 
             />
             <label class="checkb">{{ checkbox.label }}</label>
           </div>

--- a/src/app/notifications/notification.component.ts
+++ b/src/app/notifications/notification.component.ts
@@ -113,9 +113,19 @@ export class NotificationComponent implements OnInit {
     { label: 'Twitter', toggle: false },
     { label: 'Youtube', toggle: false }
   ];
-  // this.translate.instant('filtre_Adpools_message')
+
   checkboxData1 = [{ label: "filtre_Adpools_message", toggle: false }];
 
+  setAllTogglesFalse(dataArray: any[]) {
+    for (const item of dataArray) {
+      item.toggle = true;
+    }
+  }
+  setAllTogglesFalsechek(checkbox: any) {
+    for (const item of checkbox) {
+      item.toggle = false;
+    }
+  }
 
 
   enableDisableRulecheck(checkbox: any) {
@@ -694,11 +704,25 @@ export class NotificationComponent implements OnInit {
   }
   
 
+
   resetFilter() {
     this.filterListType = [];
     this.dataNotificationFilter = this.dataNotification;
+    this.setAllTogglesFalse(this.buttonData1);
+    this.setAllTogglesFalse(this.buttonData2);
+    this.setAllTogglesFalse(this.buttonData3);
+    this.setAllTogglesFalsechek(this.checkboxData);
+    this.setAllTogglesFalsechek(this.checkboxData1);
+    
+    // Remove 'checkbck' class and add 'checkb' class to all checkboxes
+    this.checkboxData.forEach(checkbox => {
+      checkbox.toggle = false;
+    });
+  
+    this.checkboxData1.forEach(checkbox => {
+      checkbox.toggle = false;
+    });
   }
-
 
   onScroll() {
     if (this.isloading) {


### PR DESCRIPTION
 

In this pull request, we've addressed the issue with checkbox styling and the behavior of the reset button. Below are the changes made to achieve the desired functionality:

TypeScript Changes:

1. Defined the `resetFilter()` function in the TypeScript file to reset all data and toggle values.
2. Modified the `setAllTogglesFalse()` function to set toggle values to `true` for button data and `false` for checkbox data.
3. Created `setAllTogglesFalsechek()` to set all checkbox toggle values to `false`.

 HTML Changes:

1. Adjusted the checkbox input element to include `[checked]` attribute to reflect the toggle state.
2. Changed the `[ngClass]` directives to apply `checkbck` class when checkbox is toggled and `checkb` class when it's not toggled.
3. Removed `class` attribute as it's not necessary when using `[ngClass]`.

Implementation Steps:

1. The `resetFilter()` function now iterates through the data arrays and sets toggle values as needed.
2. In the HTML, checkbox inputs are now checked/unchecked based on their toggle states.
3. The `[ngClass]` directives apply appropriate classes for checkbox styling based on the toggle state.
