### PR TITLE
fix the time of message of  adding facebook account without page and refactoring setUrlMSG function

### DIFF
--- a/src/app/user-settings/components/social-networks/social-networks.component.ts
+++ b/src/app/user-settings/components/social-networks/social-networks.component.ts
@@ -246,68 +246,62 @@ export class SocialNetworksComponent implements OnInit {
   //get errors from url
  
   setUrlMsg(p: Params, data: IGetSocialNetworksResponse): void {
-    
-
-    if (p.message) {
-      if (p.message === 'access-denied') {
-        this.errorMessage = 'access-cancel';
-        setTimeout(() => {
-          this.errorMessage = '';
-          this.router.navigate(['/home/settings/social-networks']);
-        }, 3000);
-      } else if (p.message === 'channel obligatoire') {
-        this.errorMessage = 'no_channel_found';
-        setTimeout(() => {
-          this.errorMessage = '';
-          this.router.navigate(['/home/settings/social-networks']);
-        }, 3000);
-      } else if (
-        p.message === 'account_linked_with_success' ||
-        p.message === 'account_linked_with_success_facebook' ||
-        p.message === 'account_linked_with_success_instagram_facebook' ||
-        p.message === 'required_page'
-      ) {
-        if (p.sn === 'fb' && data.facebook.length === 0) {
-          this.errorMessage = 'no_page_selected';
-        } else {
-          this.router.navigate(['/home/settings/social-networks']);
-          this.successMessage = 'account_linked_with_success';
-        }
-        setTimeout(() => {
-          this.successMessage = '';
-          this.router.navigate(['/home/settings/social-networks']);
-        }, 3000);
-      } else if (p.message === 'account exist') {
-        this.router.navigate(['/home/settings/social-networks']);
-        this.errorMessage = 'account_linked_other_account';
-        setTimeout(() => {
-          this.errorMessage = '';
-          this.router.navigate(['/home/settings/social-networks']);
-        }, 3000);
-      } else if (p.message === 'external_account') {
-        this.errorMessage = 'Your facebook page ';
-        setTimeout(() => {
-          this.errorMessage = 'account_linked_other_account';
-          this.router.navigate(['/home/settings/social-networks']);
-        }, 3000);
-      } 
-      else if (p.message === 'page already exists') {
-        this.errorMessage = 'page already exists';
-        setTimeout(() => {
-          // this.ngOnInit();
-          this.errorMessage = '';
-          this.router.navigate(['/home/settings/social-networks']);
-        }, 3000);
+    const showMessage = (message: string, type: 'error' | 'success', redirect = true): void => {
+      if (type === 'error') {
+        this.errorMessage = message;
+      } else if (type === 'success') {
+        this.successMessage = message;
       }
-      else if (p.message === 'required_page') {
-
-        setTimeout(() => {
-          this.errorMessage = 'no_page_selected';
+      setTimeout(() => {
+        this.errorMessage = '';
+        this.successMessage = '';
+        if (redirect) {
           this.router.navigate(['/home/settings/social-networks']);
-        }, 3000);
-      } 
+        }
+      }, 3000);
+    };
+  
+    switch (p.message) {
+      case 'access-denied':
+        showMessage('access-cancel', 'error');
+        break;
+  
+      case 'channel obligatoire':
+      case 'required_page':
+        showMessage('no_channel_found', 'error');
+        break;
+  
+      case 'account_linked_with_success':
+      case 'account_linked_with_success_facebook':
+      case 'account_linked_with_success_instagram_facebook':
+        if (p.sn === 'fb' && data.facebook.length === 0) {
+          showMessage('no_page_selected', 'error', false);
+        } else {
+          showMessage('account_linked_with_success', 'success');
+        }
+        break;
+  
+      case 'account exist':
+        showMessage('account_linked_other_account', 'error');
+        break;
+  
+      case 'external_account':
+        showMessage('Your facebook page', 'error', false);
+        break;
+  
+      case 'page already exists':
+        showMessage('page already exists', 'error');
+        break;
+  
+      case 'required_page':
+        showMessage('no_page_selected', 'error');
+        break;
+  
+      default:
+        break;
     }
   }
+  
 
   onReditectSocial(social: string) {
     //let url = this.router.url.split('?')[0];


### PR DESCRIPTION
Dear team,

This PR addresses two issues related to adding a Facebook account and error messaging. The following changes have been made:

Fixing Adding Facebook Account Without Page: We have resolved the issue where adding a Facebook account without a linked page was causing errors. The fix ensures that users can successfully add a Facebook account even if there is no associated page.

Error Message Enhancement: We have improved the error message "No page was selected!" to provide more context and guidance to users. The enhanced message offers clear information about the issue and how to proceed, enhancing the user experience.

By making these adjustments, we ensure smoother interaction with Facebook account linking and provide more helpful error messaging.

Reviewers, please verify that users can now add Facebook accounts without pages and that the error message "No page was selected!" has been effectively improved. Test the interactions and error scenarios to ensure that the user experience is enhanced. Your feedback, suggestions, and alternative approaches to further optimize the Facebook account linking and error messaging are highly appreciated.

Thank you for your attention to detail and your dedication to delivering a seamless and user-friendly platform.

Best regards,
Rania Morheg