### PR TITLE
fix the redirection of the button back in recover gains component , t…

### DIFF
--- a/src/app/campaigns/components/recover-gains/recover-gains.component.ts
+++ b/src/app/campaigns/components/recover-gains/recover-gains.component.ts
@@ -253,7 +253,8 @@ export class RecoverGainsComponent implements OnInit {
   }
   back() {
     //  this.location.back();
-    this.router.navigate(['/home/campaign/' + this.campaignId]);
+    // this.router.navigate(['/home/campaign/' + this.campaignId]);
+    this.router.navigate(['/home/farm-posts']);
   }
 
   parentFunction() {


### PR DESCRIPTION
### **Description:**
In this commit, we have addressed an issue regarding the button redirection in the "Recover Gains" component. Previously, clicking the button would take users to the campaign page. With this fix, the button will now correctly navigate users back to the post farming page, providing a smoother and more intuitive user experience.

Please take a moment to review this commit and ensure that the changes align with our project's objectives. Any feedback or suggestions you may have are greatly appreciated.

Thank you for your time and attention to this matter.
Skander