### PR TITLE
refactor notifications title description text now it should be always…

### DIFF
--- a/src/app/notifications/notification.component.css
+++ b/src/app/notifications/notification.component.css
@@ -216,6 +216,11 @@ input[type='search']::-webkit-search-cancel-button {
   /* border-top:  0.25px solid rgba(117, 117, 143, 0.3) !important; */
   /* Color #75758f with 30% opacity */
   border-bottom: 0.25px solid rgba(117, 117, 143, 0.3) !important;
+
+  /* should add an hr under the ng for for the lline better than use border-bottom  */
+  width: 70vh;
+  /* the border bottom take the width of the div which is actually 50% of the view port to increase the border we should increase the width for the div */
+  /* if there is some problem with the design please comment the line 221  */
 }
 
 
@@ -235,6 +240,7 @@ input[type='search']::-webkit-search-cancel-button {
   height: 50px;
 }
 .container_title_notification_general{
+  padding-bottom: 1em;
   width: 39em;
 }
 
@@ -277,6 +283,8 @@ input[type='search']::-webkit-search-cancel-button {
 }
 
 .label_time_notif {
+  padding-bottom: 0.5em;
+  margin-bottom: 0px;
   font-style: normal;
   font-weight: normal;
   font-size: 14px;


### PR DESCRIPTION
centered removing extra margin and add some padding to center everything also change the width of div notification to get and an homogene seperation line beetween screens , by increasing the width of the div we increase the bottom border in the futur maybe we should add an hr or a line and not use border bottom of the div this will make everything more homogene and also better in the futur if we need to change some details about the notif