### PR TITLE
fix redirection vers login page from capign

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -39,6 +39,7 @@ export function app(): express.Express {
     'html',
     ngExpressEngine({
       bootstrap: AppServerModule,
+      inlineCriticalCss: false,
       providers: [
         { provide: 'document', useValue: fakeWindow.document },
       ],
@@ -66,9 +67,12 @@ export function app(): express.Express {
   };
 
   server.get('/campaign/**/edit', getStaticFiles);
+  server.get('/campaign/**/recover-my-gains', getStaticFiles);
+  server.get('/campaign/**/verify-link', getStaticFiles);
+
 
   // All regular routes use the Universal engine
-  server.get('/campaign/**', (req,res) => {
+  server.get('/campaign/**', (req, res) => {
     res.render('index', {
       req,
       providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }]


### PR DESCRIPTION

Description:
This pull request addresses an issue that occurs when refreshing or accessing the gain recovery and link verification pages under the '/campaign/**/' endpoints. Currently, when users refresh or visit these pages, they are unexpectedly redirected to the login page. This behavior is unintended and undesirable.

To resolve this issue, the pull request introduces a configuration change by setting `inlineCriticalCss` to `false` in the `ngExpressEngine` initialization. By doing so, we disable the inline critical CSS for the relevant endpoints, which should help eliminate the unwanted redirection to the login page.

Code Changes:
- Modified `ngExpressEngine` configuration in the code to include `inlineCriticalCss: false`.

ngExpressEngine({
  bootstrap: AppServerModule,
  inlineCriticalCss: false, // Disable inline critical CSS
  providers: [
    { provide: 'document', useValue: fakeWindow.document },
  ],
})
```

Additionally, the code includes the relevant routes for the '/campaign/**/' endpoints:

server.get('/campaign/**/recover-my-gains', getStaticFiles);
server.get('/campaign/**/verify-link', getStaticFiles);
```

With this pull request, the unexpected redirection issue should be resolved, and users will be able to access the gain recovery and link verification pages under the '/campaign/**/' endpoints without encountering any redirection to the login page.

Please review and test the changes to ensure they work as intended. If there are any concerns or questions, feel free to ask or provide feedback on the pull request.

Thank you for your attention to this issue, and your feedback is much appreciated.

Sincerely,
