### PR TITLE
solve the issue with the campaign , now the user can create a campaign

### DIFF
--- a/src/app/campaigns/components/draft-campaign-presentation/draft-campaign-presentation.component.ts
+++ b/src/app/campaigns/components/draft-campaign-presentation/draft-campaign-presentation.component.ts
@@ -75,14 +75,14 @@ export class DraftCampaignPresentationComponent implements OnInit {
     @Inject(PLATFORM_ID) private platformId: string
   ) {
     this.form = fb.group({
-      titles: ['', Validators.required],
+      titles: [''],
       title: ['', Validators.required],
       summary: ['', Validators.required],
       description: [''] // Assuming you have a description field in your formtitle
     });
     this.render = rendererFactory.createRenderer(null, null);
     this.form = new UntypedFormGroup({
-      titles: new UntypedFormControl('', Validators.required),
+      titles: new UntypedFormControl(''),
       title: new UntypedFormControl('', Validators.required),
       brand: new UntypedFormControl('', Validators.required),
       reference: new UntypedFormControl(''),


### PR DESCRIPTION
**Note for Reviewers:**

This commit addresses a critical issue related to the campaign creation process. After thoroughly investigating the problem, I found that the new "titles" variable included some required validators that were unexpectedly blocking the campaign creation. By removing these validators, I was able to restore the campaign creation functionality without any further disruptions.

This fix ensures that users can once again create campaigns seamlessly without encountering any obstacles related to the "titles" variable. The code has been updated accordingly to resolve this issue and maintain the smooth functioning of the campaign creation process.

Your feedback and insights are greatly appreciated as we continue to improve the platform.

Best Regards
Skander Khabou