### PR TITLE
 Added Important Rule for .navbar-trans Background

### DIFF
--- a/src/app/layout/components/header/header.component.scss
+++ b/src/app/layout/components/header/header.component.scss
@@ -1835,7 +1835,7 @@ bottom: 77.54% ; */
     180deg,
     rgba(31, 35, 55, 0.35) 17.22%,
     rgba(31, 35, 55, 0) 100%
-  );
+  ) !important;
   /*background: linear-gradient(
     180deg,
     rgba(31, 35, 55, 0.7) 27.82%,


### PR DESCRIPTION
Description:
In this pull request, I've made an important update to the `.navbar-trans` class in the code. The purpose of this change is to ensure that the background style defined for `.navbar-trans` takes precedence over any other styles applied to it, which can be particularly useful in certain situations.

Here's the specific change I made:

```css
.navbar-trans {
  background: linear-gradient(
    180deg,
    rgba(31, 35, 55, 0.35) 17.22%,
    rgba(31, 35, 55, 0) 100%
  ) !important;
}
```

I added the `!important` declaration to the `background` property. This will make sure that this gradient background definition always takes precedence, even if other styles are applied to the `.navbar-trans` class elsewhere in the codebase.

This change is important for maintaining a consistent visual appearance for the `nav-trans` class, especially in scenarios where there might be conflicts with other styles or dynamic changes in the application. It will help ensure that the intended background style is always applied.

Please review this change and let me know if any further adjustments or clarifications are needed.