### PR TITLE
fix funds campagne in nontification

### DIFF
--- a/src/app/notifications/notification.component.ts
+++ b/src/app/notifications/notification.component.ts
@@ -1184,7 +1184,7 @@ export class NotificationComponent implements OnInit {
     );
   }
   getRetrieveBudget(cmp: any) {
-    return parseFloat(cmp.cost) / 10 ** 18;
+    return parseFloat(cmp.funds[1]) / 10 ** 18;
   }
 
   getRetrieveBudgetDays(cmp: any) {


### PR DESCRIPTION

**Changes Made:**
In this pull request, I made a modification to the `getRetrieveBudget` function to improve its accuracy in displaying the budget of a campaign. 

**Previous Code:**
getRetrieveBudget(cmp: any) {
  return parseFloat(cmp.cost) / 10 ** 18;
}
```

**New Code:**
getRetrieveBudget(cmp: any) {
  return parseFloat(cmp.funds[1]) / 10 ** 18;
}
```

The key change is in how the budget is retrieved. Previously, it used `cmp.cost`, but the new code uses `cmp.funds[1]`. This change ensures that the budget of the campaign is displayed correctly.

This modification is essential as it resolves the discrepancy in how the budget is fetched, making it more accurate and aligned with the desired functionality.

Please review and approve this change to ensure the budget is displayed correctly for campaigns.